### PR TITLE
Disable metrics server

### DIFF
--- a/main.go
+++ b/main.go
@@ -57,7 +57,6 @@ func init() {
 
 func main() {
 	var enableLeaderElection bool
-	//var probeAddr string
 	var csiAddress string
 	var workerThreads int
 	var retryIntervalStart time.Duration

--- a/main.go
+++ b/main.go
@@ -56,7 +56,6 @@ func init() {
 }
 
 func main() {
-	var metricsAddr string
 	var enableLeaderElection bool
 	//var probeAddr string
 	var csiAddress string
@@ -73,10 +72,7 @@ func main() {
 	flag.DurationVar(&csiOperationTimeout, "timeout", 10*time.Second, "Timeout of waiting for response for CSI Driver")
 	//flag.StringVar(&vgContextKeyPrefix, "context-prefix", "", "All the volume-group-attribute-keys with this prefix are added as annotation to the DellCSIVolumeGroup")
 	flag.Parse()
-	//controllers.InitLabelsAndAnnotations(domain)
 
-	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
-	//flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -110,7 +106,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,
-		MetricsBindAddress: metricsAddr,
+		MetricsBindAddress: "0",
 		Port:               9443,
 		LeaderElection:     enableLeaderElection,
 		LeaderElectionID:   leaderElectionID,


### PR DESCRIPTION
# Description
Disable metrics server. driver sidecar health metrics runs on same port.
we can enable later on  a different port.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] helm test
