### PR TITLE
go version bump-up

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/dell/csi-volumegroup-snapshotter
 
 go 1.22
-toolchain 1.22.0
+toolchain go1.22.0
 
 require (
 	github.com/dell/dell-csi-extensions/common v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,7 @@
+toolchain
 module github.com/dell/csi-volumegroup-snapshotter
 
-go 1.21
-
-toolchain go1.21.0
+go 1.22
 
 require (
 	github.com/dell/dell-csi-extensions/common v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
-toolchain
 module github.com/dell/csi-volumegroup-snapshotter
 
 go 1.22
+toolchain 1.22.0
 
 require (
 	github.com/dell/dell-csi-extensions/common v1.3.0


### PR DESCRIPTION
Updating go version to latest available i.e. => 1.22